### PR TITLE
add a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,120 @@
+> Node.js Inclusivity WG
+
+# Code of Conduct
+> This CoC is an adaptation of the [npm Code of Conduct].
+
+The Node.js Inclusivity Working Group exists to improve inclusivity
+and diversity in the Node.js project and surrounding community.
+
+We believe that our mission is best served in an environment that is
+friendly, safe, and accepting; free from intimidation or harassment.
+
+Towards this end, certain behaviors and practices will not be
+tolerated.
+
+## tl;dr
+
+* Be respectful.
+* Abusive behavior is never tolerated.
+* Violations of this code may result in swift and permanent expulsion
+  from the Node.js inclusivity working group and/or escalation to the
+  Node.js moderation group and TSC
+
+## Scope
+
+This policy covers behavior within the context of the Node.js
+Inclusivity Working Group. It is expected that all Working Group members,
+Node.js community members, and commenters participating in Inclusivity
+Working Group affairs abide by this Code of Conduct at all times in all
+public or private venues.
+
+The definitions of various subjective terms such as "discriminatory",
+"hateful", or "confusing" will be decided at the sole discretion of
+the Node.js Inclusivity Working Group team members.
+
+## Friendly Harassment-Free Space
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of gender identity, sexual
+orientation, ability, ethnicity, religion, age, physical
+appearance, body size, race, or similar personal characteristics.
+
+Any spamming, trolling, flaming, baiting, or other attention-stealing
+behavior is not welcome, and will not be tolerated.
+
+Harassing other Working Group participants is never tolerated, whether
+via public or private media.
+
+Avoid using offensive or harassing names, nicknames, or other
+identifiers that might detract from a friendly, safe, and welcoming
+environment for all.
+
+Harassment includes, but is not limited to: harmful or prejudicial
+verbal or written comments related to gender identity, sexual
+orientation, ability, ethnicity, religion, age, physical
+appearance, body size, race, or similar personal characteristics;
+inappropriate use of nudity, sexual images, and/or sexually explicit
+language in public spaces; threats of physical or non-physical harm;
+deliberate intimidation, stalking or following; harassing photography
+or recording; sustained disruption of talks or other events;
+inappropriate physical contact; and unwelcome sexual attention.
+
+## Reporting Violations of this Code of Conduct
+
+If you believe someone is harassing you or has otherwise violated this
+Code of Conduct, please contact us at inclusitivy@nodejs.org to send
+us an abuse report.  If this is the initial report of a problem, please
+include as much detail as possible. The more context we have, the better
+we can assess and resolve the situation.
+
+## Consequences
+
+All participation in this Working Group is at the sole discretion of
+the Working Group members.
+
+Anyone asked to stop unacceptable behavior is expected to comply
+immediately.
+
+If a community member engages in unacceptable behavior, the Working
+Group members may take any action they deem appropriate, up to and
+including a temporary ban or permanent expulsion from the community
+without warning.
+
+## Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating
+this Code of Conduct, you should notify the Working Group by emailing
+us at inclusivity@nodejs.org.  We will do our best to ensure that
+your grievance is handled appropriately.
+
+In general, we will choose the course of action that we judge as being
+most in the interest of fostering a safe and friendly community.
+
+## Contact Info
+
+Please contact inclusivity@nodejs.org if you need to report a problem or
+address a grievance related to an abuse report.
+
+You are also encouraged to contact us if you are unsure if something
+is appropriate or inappropriate.  We are happy to provide guidance
+to help you be a successful part of our community.
+
+## Changes
+
+This is a living document and may be updated from time to time.
+Please refer to the [git history for this
+document](https://github.com/node/inclusivity/commits/master/CODE_OF_CONDUCT.md)
+to view the changes.
+
+## Credit and License
+
+This Code of Conduct is based on the [npm Code of Conduct].
+
+This Code of Conduct borrows heavily from the Stumptown Syndicate
+[Citizen's Code of Conduct](http://citizencodeofconduct.org/), and the
+[Rust Project Code of Conduct](https://www.rust-lang.org/conduct.html).
+
+This document may be reused under a 
+[Creative Commons Attribution-ShareAlike License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+[npm Code of Conduct]: https://www.npmjs.com/policies/conduct


### PR DESCRIPTION
this is npm's coc with some minor changes.
the node code of conduct is not complete enough.
i would like to enforce a more specific and actionable one here.
if node is interested in upstreaming this, that would be wonderful.

would love help cleaning out the npm specific content.
also we need an email address for abuse reports.

if you find mistakes please feel free to submit a PR to this branch! let me know if you need help with that at all.