### PR TITLE
Doc tweaks

### DIFF
--- a/docs/admissions-policy.md
+++ b/docs/admissions-policy.md
@@ -21,6 +21,7 @@ Applications will be considered using the following criteria:
 - Does the applicant have a reasonable understanding of inclusivity and diversity?
 - Does the applicant seem sincere in their application, i.e. not a troll?
 - Does the applicant bring a new perspective to the Inclusivity Working Group?
+- Has the applicant previously contributed to the Inclusivity Working Group on GitHub or in Slack? (major bonus points)
 
 # Response steps:
 

--- a/docs/roles-responsibilities.md
+++ b/docs/roles-responsibilities.md
@@ -70,7 +70,8 @@ Contributor are expected to follow the [Code of Conduct](https://github.com/node
 
 Contributors have the following level of access and permissions for the working group.
 
-- Have access to public slack channel. This does not currently exist, but will be created some time in the near future.
+- Have access to public slack channel
+    - You can invite yourself [here](http://node-inclusivity.nebri.us/).
 - Github:
     - Content: view.
     - Issues: view, create, comment.


### PR DESCRIPTION
I updated the roles and responsibilities guide to link to the Slack inviter, and added a decision criteria to the admissions policy that used to be unofficial.