### PR TITLE
Updated removal instructions to include README

### DIFF
--- a/docs/remove-member-template.md
+++ b/docs/remove-member-template.md
@@ -5,6 +5,7 @@
 ```md
 * [ ] [Remove them from the inclusivity@iojs.org mailing list](https://github.com/nodejs/email/edit/master/iojs.org/aliases.json).
 * [ ] [Remove them from the Inclusivity GitHub team](https://github.com/orgs/nodejs/teams/inclusivity).
+* [ ] [Remove them from the Inclusivity README list of members](https://github.com/nodejs/inclusivity#members)
 * Slack
   * [ ] [Set them as a Member](https://node-inclusivity.slack.com/admin#active) (can only be done by owners).
   * [ ] Remove them from the members-only channels.


### PR DESCRIPTION
When we remove someone, we also need to remove them from the current list of members in the README.